### PR TITLE
Add observation details modal, UI and layout changes to upload pages

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: psf/black@stable
         with:
-          options: "--check --verbose"
+          options: "--check --verbose --diff"
       - uses: chartboost/ruff-action@v1
         with:
           args: "check --output-format=github"

--- a/repository/forms.py
+++ b/repository/forms.py
@@ -224,7 +224,6 @@ class SingleObservationForm(Form):
             errors[
                 "sat_ra_uncert_deg"
             ] = "Right ascension uncertainty requires right ascension."
-        # fmt: on
         if not cleaned_data.get("sat_dec_deg") and cleaned_data.get(
             "sat_dec_uncert_deg"
         ):
@@ -248,5 +247,6 @@ class SingleObservationForm(Form):
             cleaned_data.get("observer_email"),
         ):
             errors["observer_email"] = "Observer email is not correctly formatted."
+        # fmt: on
         if errors:
             raise forms.ValidationError(errors)

--- a/repository/models.py
+++ b/repository/models.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
 from django.db import models
+from rest_framework import serializers
 
 
 class Satellite(models.Model):
@@ -29,6 +30,12 @@ class Satellite(models.Model):
     def save(self, *args, **kwargs):
         self.full_clean()
         super().save(*args, **kwargs)
+
+
+class SatelliteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Satellite
+        fields = ("sat_name", "sat_number", "constellation", "date_added")
 
 
 class Location(models.Model):
@@ -68,6 +75,12 @@ class Location(models.Model):
         super().save(*args, **kwargs)
 
 
+class LocationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Location
+        fields = ("obs_lat_deg", "obs_long_deg", "obs_alt_m", "date_added")
+
+
 class Observation(models.Model):
     OBS_MODE_CHOICES = [
         ("VISUAL", "Visual"),
@@ -103,11 +116,13 @@ class Observation(models.Model):
 
     def __str__(self):
         return (
-            str(self.obs_time_utc)
-            + ", "
-            + self.obs_email
+            str(self.id)
             + ", "
             + self.satellite_id.sat_name
+            + ", "
+            + str(self.obs_time_utc)
+            + ", "
+            + self.obs_email
         )
 
     class Meta:
@@ -164,9 +179,44 @@ class Observation(models.Model):
         if self.range_rate_sat_uncert_km_s and (self.range_rate_sat_uncert_km_s < 0):
             raise ValidationError("Range rate uncertainty must be positive.")
         validate = URLValidator()
+
         if self.data_archive_link and not validate(self.data_archive_link):
             raise ValidationError("Data archive link is not correctly formatted.")
 
     def save(self, *args, **kwargs):
         self.full_clean()
         super().save(*args, **kwargs)
+
+
+class ObservationSerializer(serializers.ModelSerializer):
+    satellite_id = SatelliteSerializer(read_only=True)
+    location_id = LocationSerializer(read_only=True)
+
+    class Meta:
+        model = Observation
+        fields = (
+            "id",
+            "obs_time_utc",
+            "obs_time_uncert_sec",
+            "apparent_mag",
+            "apparent_mag_uncert",
+            "instrument",
+            "obs_mode",
+            "obs_filter",
+            "obs_email",
+            "obs_orc_id",
+            "sat_ra_deg",
+            "sat_ra_uncert_deg",
+            "sat_dec_deg",
+            "sat_dec_uncert_deg",
+            "range_to_sat_km",
+            "range_to_sat_uncert_km",
+            "range_rate_sat_km_s",
+            "range_rate_sat_uncert_km_s",
+            "comments",
+            "data_archive_link",
+            "flag",
+            "satellite_id",
+            "location_id",
+            "date_added",
+        )

--- a/repository/templates/repository/base.html
+++ b/repository/templates/repository/base.html
@@ -28,12 +28,12 @@
             <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle text-light" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                Upload
+                Submit data
               </a>
               <ul class="dropdown-menu">
-                <li><a class="dropdown-item" aria-current="page" href="{% url 'index' %}">Upload file</a></li>
-                <li><a class="dropdown-item" aria-current="page" href="{% url 'upload-obs' %}">Upload single obs.</a></li>
-                <li><a class="dropdown-item" aria-current="page" href="{% url 'data-format' %}">Upload format</a></li>
+                <li><a class="dropdown-item" aria-current="page" href="{% url 'index' %}">Upload observation file</a></li>
+                <li><a class="dropdown-item" aria-current="page" href="{% url 'upload-obs' %}">Submit single observation</a></li>
+                <li><a class="dropdown-item" aria-current="page" href="{% url 'data-format' %}">Data format</a></li>
               </ul>
             </li>
 
@@ -120,7 +120,7 @@
                 style="width: 60px; background-color: #4d85ff; height: 2px"
                 />
             <p><i class="fab fa-github"></i> <a href="#" class="text-white">Github</a></p>
-            <p><i class="fas fa-envelope mr-3"></i> sathub@iau.cps.org</p>
+            <p><i class="fas fa-envelope mr-3"></i> sathub@cps.iau.org</p>
           </div>
           <!-- Grid column -->
         </div>

--- a/repository/templates/repository/base.html
+++ b/repository/templates/repository/base.html
@@ -1,6 +1,7 @@
 {% load static %}
 {% load compress %}
 
+
 <!doctype html>
 <html lang="en">
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
@@ -21,7 +22,7 @@
     <nav class="navbar navbar-expand-lg bg-primary border-bottom border-5 border-secondary">
         <div class="container-fluid p ">
         <a class="navbar-brand fs-3  text-white" href="{% url 'index' %}">Satellite Constellation Observation Repository</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+        <button class="navbar-toggler" type="button" data-bs-theme="dark" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
@@ -38,7 +39,7 @@
             </li>
 
             <li class="nav-item">
-                <a class="nav-link text-light" href="{% url 'view-data' %}">View Data</a>
+                <a class="nav-link text-light" href="{% url 'view-data' %}">Recent observations</a>
             </li>
             <li class="nav-item">
                 <a class="nav-link text-light" href="{% url 'search' %}">Search</a>
@@ -143,10 +144,48 @@
   </footer>
 
     <script src="https://cdn.jsdelivr.net/npm/jquery/dist/jquery.min.js"></script>
-
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
     <script src="https://unpkg.com/bootstrap-table@1.22.1/dist/bootstrap-table.min.js"></script>
 
+    <script>
+
+      $(document).ready(function() {
+          $('#obsTable tr, #showObsModal').click(function() {
+              var rowData = $(this).data('content');
+              var escapedJSON = rowData.replace(/\\u0022/g, '\"').replace(/\\u002D/g, '-').replace(/b\\u0027/g, '').replace(/\\u0027/g, '');
+
+              var observation = JSON.parse(escapedJSON);
+
+              $('#observation_id').text(observation.id);
+              $('#satellite_name').text(observation.satellite_id.sat_name);
+              $('#satellite_number').text(observation.satellite_id.sat_number);
+              $('#satellite_constellation').text(observation.satellite_id.constellation);
+              $('#obs_time_utc').text(observation.obs_time_utc);
+              $('#obs_time_uncert').text(observation.obs_time_uncert_sec);
+              $('#date_added').text(observation.date_added);
+              $('#apparent_mag').text(observation.apparent_mag);
+              $('#apparent_mag_uncert').text(observation.apparent_mag_uncert);
+              $('#obs_lat_deg').text(observation.location_id.obs_lat_deg);
+              $('#obs_long_deg').text(observation.location_id.obs_long_deg);
+              $('#obs_alt_m').text(observation.location_id.obs_alt_m);
+              $('#obs_mode').text(observation.obs_mode);
+              $('#obs_filter').text(observation.obs_filter);
+              $('#obs_instrument').text(observation.obs_instrument);
+              $('#obs_orc_id').text(observation.obs_orc_id);
+              $('#obs_comments').text(observation.obs_comments);
+              $('#sat_ra_deg').text(observation.sat_ra_deg);
+              $('#sat_ra_uncert_deg').text(observation.sat_ra_uncert_deg);
+              $('#sat_dec_deg').text(observation.sat_dec_deg);
+              $('#sat_dec_uncert_deg').text(observation.sat_dec_uncert_deg);
+              $('#range_to_sat_km').text(observation.range_to_sat_km);
+              $('#range_to_sat_uncert_km').text(observation.range_to_sat_uncert_km);
+              $('#range_rate_km_s').text(observation.range_rate_sat_km_s);
+              $('#range_rate_uncert_km_s').text(observation.range_rate_sat_uncert_km_s);
+              $('#data_archive_link').text(observation.data_archive_link);
+
+          });
+      });
+  </script>
   </body>
 
   </html>

--- a/repository/templates/repository/index.html
+++ b/repository/templates/repository/index.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <div class="container-fluid p-3">
-    <div class="d-grid gap-3 pt-3 opacity-100" style="grid-template-columns: 2.25fr 375px;">
+    <div class="d-grid gap-3 pt-3 opacity-100" style="grid-template-columns: 2.25fr 380px;">
       <div>
         <div class="container p-3 mb-3">
         Insert explanatory text here about the purpose of the database, something about the
@@ -47,30 +47,18 @@
             style="--bs-bg-opacity: .2;">
             <span class="fw-bold">Upload successful!</span>
 
-            <p>{{ obs_id|length }} observation(s) added to the database.</p>
+            <p>{{ obs_id|length }} observation(s) added to the database at {{ date_added }}.</p>
             <p class="mb-3">Confirmation email with observation ID(s) sent to: test@email.com</p>
             <p>Observation ID(s) with corresponding satellite name and observation date/time
               can also be downloaded as a .txt file:</p>
-            <button class="btn btn-primary btn-sm mb-3" type="button"
-             data-bs-toggle="collapse" data-bs-target="#collapseObsIds"
-              aria-expanded="false" aria-controls="collapseObsIds">
-              Download file
-            </button>
-
-            <div class="collapse" id="collapseObsIds">
-              <div class="card card-body mb-2">
-                <p>Observation ID(s):<br />
-                  {% for id in obs_id %}
-                    {% if forloop.last %}
-                    {{ id }}
-                    {% else %}
-                    {{ id }} <br />
-                    {% endif %}
-                  {% endfor %}
-                </p>
-              </div>
-            </div>
-
+            <form action="/download-ids" method="post">
+              {% csrf_token %}
+              <input type="hidden" name="obs_ids" value="{{ obs_id|join:', ' }}">
+              <button class="btn btn-primary btn-sm mb-3" type="submit"
+               aria-controls="downloadObsIds">
+                Download file
+              </button>
+            </form>
           </div>
           {% endif %}
 
@@ -81,21 +69,23 @@
         <div class="shadow rounded-2 mb-3" style="min-height:50px;">
           <h5 class="card-title text-center bg-accent1 p-3 rounded-top-2 ">Recent observations</h5>
           <div class="card-body bg-light rounded-bottom-2 p-3">
-          {% if latest_obs_list %}
-            <ul>
-            {% for obs in latest_obs_list %}
-                <li>{{ obs.date_added }} - {{ obs.satellite_id.sat_name}}</li>
-            {% endfor %}
-            </ul>
-          {% else %}
-            <p>No observations are available.</p>
-          {% endif %}
+            {% if latest_obs_list %}
+              {% for obs, obs_json in latest_obs_list %}
+
+              <a href="#obsModal" id="showObsModal" class="btn btn-custom" data-content="{{obs_json|escapejs|safe}}" data-bs-toggle="modal"  role="button">
+                {{ obs.date_added }} - {{ obs.satellite_id.sat_name}}</a>
+              {% endfor %}
+
+            {% else %}
+              <p>No observations are available.</p>
+            {% endif %}
           </div>
+          {% include "repository/modal.html" %}
         </div>
 
         <div class="shadow bg-body rounded-2 mb-3" style="min-height: 50px;">
           <h5 class="card-title text-center bg-accent1 rounded-top-3 p-3">Statistics</h5>
-          <div class="card-body bg-light p-3 rounded-bottom-2">
+          <div class="card-body bg-light p-3 rounded-bottom-2 text-center">
 
             {% if not observation_count and not satellite_count %}
               <p>No stats are available.</p>

--- a/repository/templates/repository/index.html
+++ b/repository/templates/repository/index.html
@@ -2,12 +2,19 @@
 
 {% block content %}
 <div class="container-fluid p-3">
-    <div class="d-grid gap-3 pt-3 opacity-100" style="grid-template-columns: 2.1fr .9fr;">
+    <div class="d-grid gap-3 pt-3 opacity-100" style="grid-template-columns: 2.25fr 375px;">
       <div>
-      <div class="bg-body-tertiary border rounded-3 p-3">
+        <div class="container p-3 mb-3">
+        Insert explanatory text here about the purpose of the database, something about the
+        dataset... Blah blah blah blah blah blah blah
+        blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah
+        blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah
+        blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah.
+        </div>
+      <div class="bg-light border rounded-3 p-3">
         <div class="container">
-            <h2 class="text-center">Upload Satellite Observations</h2>
-            <p>Insert explanatory text here about how to upload observations,
+            <h3 class="text-center">Upload Observation File</h3>
+            <p class="p-3 mt-3">Insert explanatory text here about how to upload observations,
                  information about the basic data format, and a link to the full data
                  format page and possibly a sample file with the correct headers.
                  Also include what happens if the data upload fails,
@@ -20,18 +27,13 @@
                 </div>
                 <div class="row d-inline-flex flex-row pt-3 align-items-center ">
                   <div class="col">
-                    <input type="submit" class="btn btn-primary fs-6" value="Upload File"
+                    <input type="submit" class="btn btn-primary" value="Upload"
                             onclick="this.form.submit(); this.disabled=true;
                             document.getElementById('loading_spinner').hidden = false;
                             return true;" name="submit_obs">
                   </div>
                   <div class="spinner-border" id="loading_spinner" role="status" hidden>
                     <span class="visually-hidden" >Loading...</span>
-                  </div>
-                  <div class="col">
-                    {% if obs_id %}
-                      <span class="text-success text-nowrap">Upload successful</span>
-                    {% endif %}
                   </div>
                 </div>
             </form>
@@ -41,11 +43,18 @@
           {% endif %}
 
           {% if obs_id %}
-          <div class="container-md border rounded-3 mt-3 pt-2 ">
-            <p>Email sent to: test@email.com</p>
+          <div class="container-md bg-success border border-success rounded-3 mt-3 pt-2 "
+            style="--bs-bg-opacity: .2;">
+            <span class="fw-bold">Upload successful!</span>
 
-            <button class="btn btn-primary btn-sm mb-3" type="button" data-bs-toggle="collapse" data-bs-target="#collapseObsIds" aria-expanded="false" aria-controls="collapseObsIds">
-              Show Observation IDs
+            <p>{{ obs_id|length }} observation(s) added to the database.</p>
+            <p class="mb-3">Confirmation email with observation ID(s) sent to: test@email.com</p>
+            <p>Observation ID(s) with corresponding satellite name and observation date/time
+              can also be downloaded as a .txt file:</p>
+            <button class="btn btn-primary btn-sm mb-3" type="button"
+             data-bs-toggle="collapse" data-bs-target="#collapseObsIds"
+              aria-expanded="false" aria-controls="collapseObsIds">
+              Download file
             </button>
 
             <div class="collapse" id="collapseObsIds">
@@ -69,10 +78,9 @@
       </div>
       </div>
       <div class="container">
-        <div class="bg-body-tertiary border rounded-3 p-3 mb-3" style="min-height: 250px;">
-          <div class="text-center">
-            <p class="fw-bold fs-5">Recent observations</p>
-          </div>
+        <div class="shadow rounded-2 mb-3" style="min-height:50px;">
+          <h5 class="card-title text-center bg-accent1 p-3 rounded-top-2 ">Recent observations</h5>
+          <div class="card-body bg-light rounded-bottom-2 p-3">
           {% if latest_obs_list %}
             <ul>
             {% for obs in latest_obs_list %}
@@ -82,61 +90,30 @@
           {% else %}
             <p>No observations are available.</p>
           {% endif %}
+          </div>
         </div>
 
-        <div class="bg-body-tertiary border rounded-3 p-3" style="min-height: 200px;">
-          <div class="text-center">
-            <p class="fw-bold fs-5">Statistics</p>
-          </div>
-
-          <div class="container ">
+        <div class="shadow bg-body rounded-2 mb-3" style="min-height: 50px;">
+          <h5 class="card-title text-center bg-accent1 rounded-top-3 p-3">Statistics</h5>
+          <div class="card-body bg-light p-3 rounded-bottom-2">
 
             {% if not observation_count and not satellite_count %}
               <p>No stats are available.</p>
             {% endif %}
 
             {% if observation_count %}
-            <div class="row">
-              <div class="col text-end py-1 px-1">
-                Observations:
-              </div>
-              <div class="col py-1 px-0" >
-                 {{ observation_count }}
-              </div>
-            </div>
+            <span class="fs-4">{{ observation_count }}</span> observations
+            <br/>
             {% endif %}
 
             {% if satellite_count %}
-            <div class="row">
-              <div class="col text-end py-1 px-1">
-                Satellites:
-              </div>
-              <div class="col  py-1 px-0" >
-                {{ satellite_count }}
-              </div>
-            </div>
+            <span class="fs-4">{{ satellite_count }}</span> satellites
+            <br/>
             {% endif %}
 
             {% if observer_count %}
-            <div class="row">
-              <div class="col text-end py-1 px-1">
-                Observers:
-              </div>
-              <div class="col py-1 px-0">
-                {{ observer_count }}
-              </div>
-            </div>
-            {% endif %}
-
-            {% if avg_mag %}
-            <div class="row">
-              <div class="col text-end py-1 px-1">
-                Avg apparent mag.:
-              </div>
-              <div class="col py-1 px-0">
-                {{ avg_mag }}
-              </div>
-            </div>
+            <span class="fs-4">{{ observer_count }}</span> observers
+            <br/>
             {% endif %}
           </div>
         </div>

--- a/repository/templates/repository/modal.html
+++ b/repository/templates/repository/modal.html
@@ -1,0 +1,46 @@
+<div id="obsModal" class="modal" role="dialog">
+    <div class="modal-dialog modal-lg modal-dialog-centered"
+    aria-labelledby="obs-modal-title" aria-hidden="true">
+        <div class="modal-content">
+            <div class="modal-header" data-bs-theme="dark" >
+                <h4 class="modal-title" id="obs-modal-title">Observation Details</h4>
+                <button type="button" class="btn-close" aria-label="Close"
+                data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body container">
+                <div class="row">
+                    <div class="col">
+                        <div class="fw-bold">Observation ID: <span class="fw-normal" id="observation_id"></span></div>
+                        <div class="fw-bold">Satellite Name: <span class="fw-normal" id="satellite_name"></span></div>
+                        <div class="fw-bold">NORAD ID: <span class="fw-normal" id="satellite_number"></span></div>
+                        <div class="fw-bold">Constellation: <span class="fw-normal" id="satellite_constellation"></span></div>
+                        <div class="fw-bold">Observation time (UTC): <span class="fw-normal" id="obs_time_utc"></span></div>
+                        <div class="fw-bold">Observation time uncertainty: <span class="fw-normal" id="obs_time_uncert"></span></div>
+                        <div class="fw-bold">Date added: <span class="fw-normal" id="date_added"></span></div>
+                        <div class="fw-bold">Apparent magnitude: <span class="fw-normal" id="apparent_mag"></span></div>
+                        <div class="fw-bold">Apparent magnitude uncertainty: <span class="fw-normal" id="apparent_mag_uncert"></span></div>
+                        <div class="fw-bold">Observation latitude (deg.): <span class="fw-normal" id="obs_lat_deg"></span></div>
+                        <div class="fw-bold">Observation longitude (deg.): <span class="fw-normal" id="obs_long_deg"></span></div>
+                        <div class="fw-bold">Observation altitude (m): <span class="fw-normal" id="obs_alt_m"></span></div>
+                        <div class="fw-bold">Observing mode: <span class="fw-normal" id="obs_mode"></span></div>
+                    </div>
+                    <div class="col">
+                        <div class="fw-bold">Filter: <span class="fw-normal" id="obs_filter"></span></div>
+                        <div class="fw-bold">Instrument: <span class="fw-normal" id="obs_instrument"></span></div>
+                        <div class="fw-bold">Observer ORCID: <span class="fw-normal" id="obs_orc_id"></span></div>
+                        <div class="fw-bold">Commments: <span class="fw-normal" id="obs_comments"></span></div>
+                        <div class="fw-bold">Satellite RA (deg.): <span class="fw-normal" id="sat_ra_deg"></span></div>
+                        <div class="fw-bold">RA uncertainty (deg.): <span class="fw-normal" id="sat_ra_uncert_deg"></span></div>
+                        <div class="fw-bold">Satellite Dec. (deg.): <span class="fw-normal" id="sat_dec_deg"></span></div>
+                        <div class="fw-bold">Dec. uncertainty: <span class="fw-normal" id="sat_dec_uncert_deg"></span></div>
+                        <div class="fw-bold">Range to satellite (km): <span class="fw-normal" id="range_to_sat_km"></span></div>
+                        <div class="fw-bold">Range uncertainty (km): <span class="fw-normal" id="range_to_sat_uncert_km"></span></div>
+                        <div class="fw-bold">Range rate (km/s): <span class="fw-normal" id="range_rate_km_s"></span></div>
+                        <div class="fw-bold">Range rate uncertainty (km/s): <span class="fw-normal" id="range_rate_uncert_km_s"></span></div>
+                        <div class="fw-bold">Data archive: <span class="fw-normal" id="data_archive_link"></span></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/repository/templates/repository/search.html
+++ b/repository/templates/repository/search.html
@@ -70,9 +70,9 @@
             <div class="container-md">
             {% if observations %}
             <div class="col p-3">
-                <div class="float-start">
+<!--                 <div class="float-start">
                     <i class="fas fa-download"></i>  <a href="{% url 'download-results' %}">Download search results</a>
-                </div>
+                </div> -->
             </div>
                 <table data-toggle="table"
                 data-pagination="true"
@@ -82,7 +82,8 @@
                 data-sort-name="added"
                 data-sort-order="desc"
                 data-classes="table"
-                class="table table-hover fs-6">
+                class="table table-hover fs-6"
+                id="obsTable">
                     <thead >
                         <tr>
                             <th scope="col" data-sortable="true" data-visible="true" >Date added</th>
@@ -98,22 +99,23 @@
                         </tr>
                     </thead>
                     <tbody class="table-group-divider">
-                    {% for observation in observations %}
-                        <tr>
+                    {% for observation, observation_json in observations %}
+                        <tr data-bs-toggle="modal" data-bs-target="#obsModal" data-content="{{observation_json|escapejs|safe}}">
                             <td scope="row">{{ observation.date_added }}</td>
                             <td scope="row">{{ observation.date_added.timestamp }}</td>
                             <td scope="row">{{ observation.satellite_id.sat_name }}</td>
                             <td scope="row">{{ observation.obs_time_utc }}</td>
-                            <td scope="row">{{ observation.apparent_mag }}</td>
-                            <td scope="row">{{ observation.location_id.obs_lat_deg }}</td>
-                            <td scope="row">{{ observation.location_id.obs_long_deg }}</td>
-                            <td scope="row">{{ observation.location_id.obs_alt_m }}</td>
+                            <td scope="row" class="text-end">{{ observation.apparent_mag }}</td>
+                            <td scope="row" class="text-end">{{ observation.location_id.obs_lat_deg }}</td>
+                            <td scope="row" class="text-end">{{ observation.location_id.obs_long_deg }}</td>
+                            <td scope="row" class="text-end">{{ observation.location_id.obs_alt_m }}</td>
                             <td scope="row">{{ observation.obs_mode }}</td>
                             <td scope="row">{{ observation.obs_orc_id }}</td>
                         </tr>
                     {% endfor %}
                     </tbody>
                 </table>
+                {% include "repository/modal.html" %}
             {% endif %}
             {% if error %}
             <div class="container-md text-center mt-5">

--- a/repository/templates/repository/upload-obs.html
+++ b/repository/templates/repository/upload-obs.html
@@ -3,24 +3,28 @@
 {% block content %}
 
 <div class="container-fluid p-3">
-    <div class="container-sm" >
+    <div class="container-sm " >
         <h2 class="text-center p-2 pb-4">Upload Single Observation</h2>
         <div class="container-fluid">
             {% if obs_id %}
             <div class="alert alert-success" role="alert">
                 <h4 class="alert-heading">Upload successful</h4>
                 Observation ID: {{ obs_id }}<br/>
-                Email sent to: {{ obs_email }}
+                Confirmation email sent to: {{ obs_email }}
             </div>
             {% endif %}
         </div>
-        <div class="text-end">
+        <div class="text-end my-3">
             <span class="text-danger">*</span> denotes required field
         </div>
-        <div class="justify-content-center ">
+        <div class="justify-content-center px-5">
             <form action="{% url 'upload-obs' %}" method="post" enctype="multipart/form-data">
                 {% csrf_token %}
+            <div class="row"><hr/></div>
             <div class="row">
+                <div class="col-sm-4 fs-5 fw-bold">
+                    Basic data
+                </div>
                 <div class="col">
                     <div class=" pb-4">
                         {{ form.sat_name.label_tag }} <span class="text-danger">*</span>
@@ -38,6 +42,7 @@
                 </div>
             </div>
             <div class="row">
+                <div class="col-sm-4 fw-bold"></div>
                 <div class="col">
                     <div class=" pb-4">
                         {{ form.obs_date.label_tag}} <span class="text-danger">*</span>
@@ -61,6 +66,7 @@
                 </div>
             </div>
             <div class="row">
+                <div class="col-sm-4 fw-bold"></div>
                 <div class="col">
                     <div class=" pb-4">
                         {{ form.obs_mode.label_tag}} <span class="text-danger">*</span>
@@ -75,6 +81,7 @@
                 </div>
             </div>
             <div class="row">
+                <div class="col-sm-4 fs-5 fw-bold"></div>
                 <div class="col">
                     <div class=" pb-4">
                         {{ form.apparent_mag.label_tag}} <span class="text-danger">*</span>
@@ -92,6 +99,7 @@
                 </div>
             </div>
             <div class="row">
+                <div class="col-sm-4 fw-bold"></div>
                 <div class="col">
                     <div class=" pb-4">
                         {{ form.instrument.label_tag}} <span class="text-danger">*</span>
@@ -105,9 +113,13 @@
                     </div>
                 </div>
             </div>
+            <div class="row mt-3"><hr/></div>
             <div class="row">
+                <div class="col-sm-4 fs-5 fw-bold">
+                    Observer information
+                </div>
                 <div class="col">
-                    <div class=" pb-4">
+                    <div class="pb-4">
                         {{ form.observer_latitude_deg.label_tag}} <span class="text-danger">*</span>
                         {{ form.observer_latitude_deg }}
                         <div class="text-danger">
@@ -136,6 +148,7 @@
             </div>
 
             <div class="row">
+                <div class="col-sm-4 fs-5 fw-bold"></div>
                 <div class="col">
                     <div class=" pb-4">
                         {{ form.observer_email.label_tag}} <span class="text-danger">*</span>
@@ -155,7 +168,11 @@
                     </div>
                 </div>
             </div>
+            <div class="row mt-3"><hr/></div>
             <div class="row">
+                <div class="col-sm-4 fs-5 fw-bold">
+                    Advanced data
+                </div>
                 <div class="col">
                     <div class=" pb-4">
                         {{ form.sat_ra_deg.label_tag}}
@@ -173,6 +190,7 @@
                 </div>
             </div>
             <div class="row">
+                <div class="col-sm-4 fw-bold"></div>
                 <div class="col">
                     <div class=" pb-4">
                         {{ form.sat_dec_deg.label_tag}}
@@ -190,6 +208,7 @@
                 </div>
             </div>
             <div class="row">
+                <div class="col-sm-4 fw-bold"></div>
                 <div class="col">
                     <div class=" pb-4">
                         {{ form.range_to_sat_km.label_tag}}
@@ -207,6 +226,7 @@
                 </div>
             </div>
             <div class="row">
+                <div class="col-sm-4 fw-bold"></div>
                 <div class="col">
                     <div class=" pb-4">
                         {{ form.range_rate_sat_km_s.label_tag}}
@@ -224,6 +244,7 @@
                 </div>
             </div>
             <div class="row">
+                <div class="col-4 fw-bold"></div>
                 <div class="col">
                     <div class=" pb-4">
                         {{ form.comments.label_tag}}

--- a/repository/templates/repository/view.html
+++ b/repository/templates/repository/view.html
@@ -3,49 +3,50 @@
 {% block content %}
 <div class="container-fluid p-3">
     <div class="container-md">
-    <h2 class="text-center p-2">Recent Observations</h2>
-    <table  data-toggle="table"
-            data-pagination="true"
-            data-search="true"
-            data-page-list="[25, 50, 100, 200, All]"
-            data-page-size="25"
-            data-sort-name="added"
-            data-sort-order="desc"
-            data-classes="table"
-            class="table table-hover fs-6">
-        <thead >
-            <tr>
-                <th scope="col" data-sortable="true" data-visible="true" >Date added</th>
-                <th data-field="added"  scope="col" data-sortable="true" data-visible="false" >Date_added_timestamp</th>
-                <th scope="col" data-sortable="true">Satellite</th>
-                <th scope="col" data-sortable="true">Date observed</th>
-                <th scope="col" data-sortable="true">Mag.</th>
-                <th scope="col" data-sortable="true">Latitude</th>
-                <th scope="col" data-sortable="true">Longitude</th>
-                <th scope="col" data-sortable="true">Altitude</th>
-                <th scope="col" data-sortable="true">Obs. mode</th>
-                <th scope="col" data-sortable="true">Obs. ORCID</th>
-            </tr>
-        </thead>
-        <tbody class="table-group-divider">
-        {% for observation in observations %}
-            <tr>
-                <td scope="row">{{ observation.date_added }}</td>
-                <td scope="row">{{ observation.date_added.timestamp }}</td>
-                <td scope="row">{{ observation.satellite_id.sat_name }}</td>
-                <td scope="row">{{ observation.obs_time_utc }}</td>
-                <td scope="row" class="text-end">{{ observation.apparent_mag }}</td>
-                <td scope="row"class="text-end">{{ observation.location_id.obs_lat_deg }}</td>
-                <td scope="row" class="text-end">{{ observation.location_id.obs_long_deg }}</td>
-                <td scope="row" class="text-end">{{ observation.location_id.obs_alt_m }}</td>
-                <td scope="row">{{ observation.obs_mode }}</td>
-                <td scope="row">{{ observation.obs_orc_id }}</td>
-            </tr>
-        {% endfor %}
-        </tbody>
-    </table>
+        <h2 class="text-center p-2">Recent Observations</h2>
+        <table  data-toggle="table"
+                data-pagination="true"
+                data-search="true"
+                data-page-list="[25, 50, 100, 200, All]"
+                data-page-size="25"
+                data-sort-name="added"
+                data-sort-order="desc"
+                data-classes="table"
+                class="table table-hover fs-6"
+                id="obsTable">
+            <thead >
+                <tr>
+                    <th scope="col" data-sortable="true" data-visible="true" >Date added</th>
+                    <th data-field="added"  scope="col" data-sortable="true" data-visible="false" >Date_added_timestamp</th>
+                    <th scope="col" data-sortable="true">Satellite</th>
+                    <th scope="col" data-sortable="true">Date observed</th>
+                    <th scope="col" data-sortable="true">Mag.</th>
+                    <th scope="col" data-sortable="true">Latitude</th>
+                    <th scope="col" data-sortable="true">Longitude</th>
+                    <th scope="col" data-sortable="true">Altitude</th>
+                    <th scope="col" data-sortable="true">Obs. mode</th>
+                    <th scope="col" data-sortable="true">Obs. ORCID</th>
+                </tr>
+            </thead>
+            <tbody class="table-group-divider">
+            {% for observation, observation_json in observations_and_json %}
+                <tr data-bs-toggle="modal" data-bs-target="#obsModal" data-content="{{observation_json|escapejs|safe}}">
+                    <td scope="row">{{ observation.date_added }}</td>
+                    <td scope="row">{{ observation.date_added.timestamp }}</td>
+                    <td scope="row">{{ observation.satellite_id.sat_name }}</td>
+                    <td scope="row">{{ observation.obs_time_utc }}</td>
+                    <td scope="row" class="text-end">{{ observation.apparent_mag }}</td>
+                    <td scope="row"class="text-end">{{ observation.location_id.obs_lat_deg }}</td>
+                    <td scope="row" class="text-end">{{ observation.location_id.obs_long_deg }}</td>
+                    <td scope="row" class="text-end">{{ observation.location_id.obs_alt_m }}</td>
+                    <td scope="row">{{ observation.obs_mode }}</td>
+                    <td scope="row">{{ observation.obs_orc_id }}</td>
+                </tr>
+            {% endfor %}
 
-
+            </tbody>
+        </table>
+        {% include "repository/modal.html" %}
     </div>
 </div>
 
@@ -54,5 +55,6 @@
         <i class="fas fa-download"></i>  <a href="{% url 'download-all' %}" class="link-dark">Download all data</a>
     </div>
 </div>
+
 
 {% endblock %}

--- a/repository/templates/repository/view.html
+++ b/repository/templates/repository/view.html
@@ -34,10 +34,10 @@
                 <td scope="row">{{ observation.date_added.timestamp }}</td>
                 <td scope="row">{{ observation.satellite_id.sat_name }}</td>
                 <td scope="row">{{ observation.obs_time_utc }}</td>
-                <td scope="row">{{ observation.apparent_mag }}</td>
-                <td scope="row">{{ observation.location_id.obs_lat_deg }}</td>
-                <td scope="row">{{ observation.location_id.obs_long_deg }}</td>
-                <td scope="row">{{ observation.location_id.obs_alt_m }}</td>
+                <td scope="row" class="text-end">{{ observation.apparent_mag }}</td>
+                <td scope="row"class="text-end">{{ observation.location_id.obs_lat_deg }}</td>
+                <td scope="row" class="text-end">{{ observation.location_id.obs_long_deg }}</td>
+                <td scope="row" class="text-end">{{ observation.location_id.obs_alt_m }}</td>
                 <td scope="row">{{ observation.obs_mode }}</td>
                 <td scope="row">{{ observation.obs_orc_id }}</td>
             </tr>
@@ -51,7 +51,7 @@
 
 <div class="col p-3">
     <div class="float-end">
-        <i class="fas fa-download"></i>  <a href="{% url 'download-all' %}">Download all data</a>
+        <i class="fas fa-download"></i>  <a href="{% url 'download-all' %}" class="link-dark">Download all data</a>
     </div>
 </div>
 

--- a/repository/tests/tests_models.py
+++ b/repository/tests/tests_models.py
@@ -187,11 +187,13 @@ class ObservationTest(TestCase):
         self.assertTrue(isinstance(obs, Observation))
         self.assertEqual(
             obs.__str__(),
-            str(obs.obs_time_utc)
+            str(obs.id)
             + ", "
-            + obs.obs_email
+            + obs.satellite_id.sat_name
             + ", "
-            + obs.satellite_id.sat_name,
+            + str(obs.obs_time_utc)
+            + ", "
+            + obs.obs_email,
         )
 
     def test_observation_validation(self):

--- a/repository/tests/tests_views.py
+++ b/repository/tests/tests_views.py
@@ -57,7 +57,7 @@ class TestViews(TestCase):
         self.assertContains(response, "STARLINK-123")
         self.assertContains(response, "VISUAL")
         self.assertContains(response, "5.2")
-        self.assertContains(response, self.obs_date.strftime("%b.%e, %Y"))
+        self.assertContains(response, self.obs_date.strftime("%b. %e, %Y"))
 
     def test_download_all(self):
         response = self.client.get("/download-all")

--- a/repository/tests/tests_views.py
+++ b/repository/tests/tests_views.py
@@ -42,10 +42,8 @@ class TestViews(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "repository/index.html")
         self.assertContains(response, "STARLINK-123")
-        self.assertContains(response, "Avg apparent mag.")
-        self.assertContains(response, "5.2")
-        self.assertContains(response, "Satellites:")
-        self.assertContains(response, "Observers:")
+        self.assertContains(response, "satellites")
+        self.assertContains(response, "observers")
 
     def test_data_format(self):
         response = self.client.get("/data-format")

--- a/repository/urls.py
+++ b/repository/urls.py
@@ -10,4 +10,5 @@ urlpatterns = [
     path("download-results", views.download_results, name="download-results"),
     path("search", views.search, name="search"),
     path("upload", views.upload, name="upload-obs"),
+    path("download-ids", views.download_obs_ids, name="download-obs-ids"),
 ]

--- a/repository/views.py
+++ b/repository/views.py
@@ -24,7 +24,6 @@ def index(request):
         "observation_count": stats.observation_count,
         "observer_count": stats.observer_count,
         "latest_obs_list": stats.latest_obs_list,
-        "avg_mag": stats.avg_mag,
     }
 
     if request.method == "POST" and not request.FILES:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 asgiref==3.7.2
 beautifulsoup4==4.12.2
-black==23.12.1
+black==24.1.1
 cfgv==3.4.0
 click==8.1.7
 coverage==7.4.0
@@ -12,6 +12,7 @@ django-bootstrap-v5==1.0.11
 django-composer==0.0.5
 django-compressor==4.4
 django-libsass==0.9
+djangorestframework==3.14.0
 filelock==3.13.1
 identify==2.5.33
 iniconfig==2.0.0
@@ -26,6 +27,7 @@ pre-commit==3.6.0
 psycopg2==2.9.9
 pytest==7.4.4
 pytest-django==4.7.0
+pytz==2024.1
 PyYAML==6.0.1
 rcssmin==1.1.1
 rjsmin==1.2.1

--- a/score/settings.py
+++ b/score/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "compressor",
+    "rest_framework",
 ]
 
 MIDDLEWARE = [

--- a/static/custom.scss
+++ b/static/custom.scss
@@ -1,38 +1,67 @@
 // Custom.scss
-// Option A: Include all of Bootstrap
 
-// Include any default variable overrides here (though functions won't be available)
+$theme-colors: (
+  "light":      #f5f5f5,
+  "dark":       #1c1e27,
+  "primary":    #142943,
+  "secondary":  #517096,
+  "tertiary":   #d7cfc5,
+  "info":       #6c9fd7,
+  "accent1":    #fbb552,
+  "accent2":    #b7d3df,
+  "accent3":    #a8acb8,
+  "success":    #20671d,
+  "warning":    #ebd119,
+  "danger":     #fe1712,
+);
 
+.page-item.active .page-link{
+  background-color: map-get($theme-colors, "primary");
+  color: map-get($theme-colors, "light");
+  border-color: #7b7b7b;
+}
 
-// Then add additional custom code here
-$primary: #0d1f4d;
-$success: #20671d;
+.page-item.active .page-link:hover{
+  background-color: map-get($theme-colors, "primary");
+  color: map-get($theme-colors, "light");
+  border-color: #7b7b7b;
+}
 
-$dark: #191d26;
+.page-item .page-link{
+  background-color: #ffffff;
+  color: #000000;
+
+}
+
+.page-item .page-link:hover{
+  background-color: #ffffff;
+  color: map-get($theme-colors, "primary");
+  border-color: #7b7b7b;
+}
+
+$dropdown-link-active-bg: map-get($theme-colors, "primary");
+
 
 $font-family-sans-serif: 'Helvetica', sans-serif;
 $font-size-base: .9rem;
 
-.btn.btn-primary:focus,
-.btn.btn-primary:active,
-.btn.btn-primary:hover {
-  background-color: #133079;
-  border-color: #f3feff;
-}
-.btn.btn-primary:disabled{
-  background-color: #3c1a51;
-  border-color: #f3feff;
-  opacity: 0.5;
+//.btn.btn-primary:focus,
+//.btn.btn-primary:active,http://127.0.0.1:8000/upload
+//.btn.btn-primary:hover {
+//  background-color: #133079;
+//  border-color: #f3feff;
+//}
+//.btn.btn-primary:disabled{
+//  background-color: #3c1a51;
+//  border-color: #f3feff;
+//  opacity: 0.5;
+//
+//}
 
-}
-.page-item.active .page-link{
-  background-color: $primary;
-  border-color: #7b7b7b;
-}
-
+//
 $form-file-button-color:         #000000;
-$form-file-button-bg:             #FFC02E;
-$form-file-button-hover-bg:       #fdce60;
+$form-file-button-bg:            map-get($theme-colors, "tertiary");
+//$form-file-button-hover-bg:       #fdce60;
 
 
 

--- a/static/custom.scss
+++ b/static/custom.scss
@@ -4,7 +4,7 @@ $theme-colors: (
   "light":      #f5f5f5,
   "dark":       #1c1e27,
   "primary":    #142943,
-  "secondary":  #517096,
+  "secondary":  #5c7da7,
   "tertiary":   #d7cfc5,
   "info":       #6c9fd7,
   "accent1":    #fbb552,
@@ -39,24 +39,34 @@ $theme-colors: (
   border-color: #7b7b7b;
 }
 
+.modal-header{
+  background-color: map-get($theme-colors, "secondary");
+  color: map-get($theme-colors, "light");
+}
+
+.btn.btn-custom {
+  padding: 0;
+}
+
+
 $dropdown-link-active-bg: map-get($theme-colors, "primary");
+$modal-header-border-color: map-get($theme-colors, "primary");
+$modal-header-border-width: 2px;
 
 
 $font-family-sans-serif: 'Helvetica', sans-serif;
 $font-size-base: .9rem;
 
-//.btn.btn-primary:focus,
-//.btn.btn-primary:active,http://127.0.0.1:8000/upload
-//.btn.btn-primary:hover {
-//  background-color: #133079;
-//  border-color: #f3feff;
-//}
-//.btn.btn-primary:disabled{
-//  background-color: #3c1a51;
-//  border-color: #f3feff;
-//  opacity: 0.5;
-//
-//}
+.btn.btn-primary:focus,
+.btn.btn-primary:active,
+.btn.btn-primary:hover {
+  background-color: rgba(map-get($theme-colors, "primary"), .95);
+  border-color: #b3b3b3;
+}
+
+.page-list .btn {
+  background-color: map-get($theme-colors, "light"); /* Change to your desired color */
+}
 
 //
 $form-file-button-color:         #000000;


### PR DESCRIPTION
Add modal to show full observation details for recent observations (main page and full page) and search results; download observation IDs with observation time and satellite name to CSV from the upload confirmation, plus general layout updates