### PR TITLE
add script to copy static files to shared storage with nginx

### DIFF
--- a/dev/kubernetes.sh
+++ b/dev/kubernetes.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# Copy Django generated static files to shared files
+# NGINX will serve these files as it also mounts the shared files volume
+cp -r /usr/src/app/static /shared-files/


### PR DESCRIPTION
Doing the copy directly using the kubernetes `command` is crashing the container atm.

Instead I will use the `command` to execute this script. This is the same technique in use on the other django installs.