### PR TITLE
Kubernetes: Modify start.sh to support copying static files to Kubernetes volume mount

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,4 @@ ARG SETTINGS
 ENV SETTINGS_CONFIG=${SETTINGS}
 ENV DJANGO_SETTINGS_MODULE=${SETTINGS}
 RUN chmod +x /usr/src/app/start.sh
-RUN chmod +x /usr/src/app/dev/kubernetes.sh
 CMD /bin/bash -c "/usr/src/app/start.sh" ${SETTINGS_CONFIG}

--- a/dev/kubernetes.sh
+++ b/dev/kubernetes.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-# Copy Django generated static files to shared files
-# NGINX will serve these files as it also mounts the shared files volume
-cp -r /usr/src/app/static /shared-files/

--- a/start.sh
+++ b/start.sh
@@ -9,7 +9,7 @@ python manage.py collectstatic --noinput
 # Kubernetes specific:
 # Copy Django generated static files to `/shared-files` if it exists.
 # An adjacent container running NGINX will serve these files as it also
-# mounts the shared files directory
+# mounts the shared files directory.
 if [ -d "/shared-files" ]; then
 	cp -r /usr/src/app/static /shared-files/
 fi

--- a/start.sh
+++ b/start.sh
@@ -6,6 +6,10 @@ python manage.py migrate
 echo "${0}: collecting static files."
 python manage.py collectstatic --noinput
 
+# Copy Django generated static files to shared files
+# NGINX will serve these files as it also mounts the shared files volume
+cp -r /usr/src/app/static /shared-files/
+
 echo "${0}: starting server."
 ENV DJANGO_SETTINGS_MODULE=$1
 gunicorn -b 0.0.0.0 -w 2 score.wsgi:application

--- a/start.sh
+++ b/start.sh
@@ -6,9 +6,13 @@ python manage.py migrate
 echo "${0}: collecting static files."
 python manage.py collectstatic --noinput
 
-# Copy Django generated static files to shared files
-# NGINX will serve these files as it also mounts the shared files volume
-cp -r /usr/src/app/static /shared-files/
+# Kubernetes specific:
+# Copy Django generated static files to `/shared-files` if it exists.
+# An adjacent container running NGINX will serve these files as it also
+# mounts the shared files directory
+if [ -d "/shared-files" ]; then
+	cp -r /usr/src/app/static /shared-files/
+fi
 
 echo "${0}: starting server."
 ENV DJANGO_SETTINGS_MODULE=$1


### PR DESCRIPTION
# Purpose 
To support serving the `/static` directory, Gunicorn recommends a reverse proxy such as NGINX.

In the Kubernetes Pod, an additional NGINX container has been created. A local volume is mounted on both the Django and NGINX containers named `/shared-files`.

The entrypoint of the Django container is `start.sh`. This file has been modified to copy the `static` directory to `shared-files`.

# The modifications
To simplify matters, the file `/dev/kubernetres.sh` has been deleted.

The contents has been ported to `/start.sh`. An additional bash directory check is included as this is very Kubernetes specific.