### PR TITLE
Update date used as archival data cutoff

### DIFF
--- a/repository/utils/general_utils.py
+++ b/repository/utils/general_utils.py
@@ -166,7 +166,7 @@ def add_additional_data(
     is_valid = validate_position(r, satellite_name, observation_time)
 
     if (
-        obs_time < Time("2024-05-01T00:00:00.000", format="isot")
+        obs_time < Time("2020-01-01T00:00:00.000", format="isot")
         and not is_valid == "archival data"
     ):
         # Temporary fix for satellite name changes


### PR DESCRIPTION
### Description:
The date used in SCORE for whether or not data was considered archival data (and therefore didn't check SatChecker for reference position information or to get satellite metadata) was 5/1/24, and I changed it to 1/1/20 to more closely match the archival data currently available in SatChecker. As SatChecker gets older TLEs, this date will need to be changed again.

