### PR TITLE
Use TLE epoch date to check if observation is archival or not

### DIFF
--- a/repository/tests/tests_utils.py
+++ b/repository/tests/tests_utils.py
@@ -61,6 +61,15 @@ def test_validate_position(requests_mock, setup_data):
                     "",  # noqa: B033
                     "",  # noqa: B033
                     "10",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "2024-02-20 00:36:13 UTC",
                 ]
             ]
         },
@@ -91,6 +100,15 @@ def test_validate_position_invalid_sat_name(requests_mock, setup_data):
                     "",  # noqa: B033
                     "",  # noqa: B033
                     "10",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "2024-02-20 00:36:13 UTC",
                 ]
             ]
         },

--- a/repository/utils/general_utils.py
+++ b/repository/utils/general_utils.py
@@ -263,7 +263,9 @@ def validate_position(
 
     satellite_info = response_data["data"][0]
     obs_time = Time(obs_time, format="isot")
-    date_str = satellite_info[6].replace(" UTC", "")
+
+    # use tle_epoch, not tle_date (that is the date it was collected)
+    date_str = satellite_info[18].replace(" UTC", "")
     tle_date = Time(date_str, format="iso", scale="utc")
     if (tle_date - obs_time).jd > 14:
         return "archival data"


### PR DESCRIPTION
### Description:
The date being used to check whether the TLE vs observation dates were out of range enough to be archival date was the date the TLE was collected, which doesn't reflect whether the TLE is accurate for the date of the observation. The archival data check has been updated to use the new tle_epoch field from SatChecker.


- [ ] Tests up to date
- [ ] Code documentation up to date
- [ ] Project documentation up to date
