### PR TITLE
Maintain current/correct satellite names and add instrument field to Search

### DIFF
--- a/repository/forms.py
+++ b/repository/forms.py
@@ -89,6 +89,11 @@ class SearchForm(Form):
         label="End Date",
         widget=forms.DateInput(attrs={"type": "date", "class": "form-control"}),
     )
+    instrument = forms.CharField(
+        required=False,
+        label="Instrument",
+        widget=forms.TextInput(attrs={"class": "form-control"}),
+    )
     observation_id = forms.IntegerField(
         required=False,
         label="Observation ID",

--- a/repository/templates/repository/search.html
+++ b/repository/templates/repository/search.html
@@ -51,6 +51,10 @@
                                 {{ form.observation_id }}
                             </div>
                             <div class="mb-3">
+                                {{ form.instrument.label_tag }}
+                                {{ form.instrument }}
+                            </div>
+                            <div class="mb-3">
                                 {{ form.start_date_range.label_tag }}
                                 {{ form.start_date_range }}
                             </div>

--- a/repository/tests/tests_views.py
+++ b/repository/tests/tests_views.py
@@ -212,6 +212,7 @@ class SearchViewTest(TestCase):
                 "end_date_range": "",
                 "observation_id": "",
                 "observer_orcid": "",
+                "instrument": "",
             },
         )
         self.assertEqual(response.status_code, 200)

--- a/repository/utils/general_utils.py
+++ b/repository/utils/general_utils.py
@@ -163,6 +163,7 @@ def add_additional_data(
         return "Satellite position check failed - try again later."
 
     is_valid = validate_position(r, satellite_name, observation_time)
+    updated_satellite_name = None
 
     if (
         obs_time < Time("2024-05-01T00:00:00.000", format="isot")
@@ -193,10 +194,10 @@ def add_additional_data(
                 )
 
                 # Name is valid - now make sure it's the most recent version
-                if satellite_found:
+                if satellite_found or (not satellite_found and satellite_name == ""):
                     for item in response_json:
-                        if item.get("is_current_version") is True:
-                            satellite_name = item.get("name")
+                        if item.get("is_current_version") == True:  # noqa: E712
+                            updated_satellite_name = item.get("name")
                             break
 
         except requests.exceptions.RequestException:
@@ -242,7 +243,7 @@ def add_additional_data(
             dra_cosdec_deg_s=round(data_dict.get("dra_cosdec_deg_per_sec", 0), 7),
             sat_dec_deg=round(data_dict.get("declination_deg", 0), 7),
             sat_ra_deg=round(data_dict.get("right_ascension_deg", 0), 7),
-            satellite_name=data_dict.get("name"),
+            satellite_name=updated_satellite_name or data_dict.get("name"),
             intl_designator=data_dict.get("international_designator"),
         )
         return satellite_data

--- a/repository/utils/general_utils.py
+++ b/repository/utils/general_utils.py
@@ -165,10 +165,14 @@ def add_additional_data(
     is_valid = validate_position(r, satellite_name, observation_time)
     updated_satellite_name = None
 
+    # There are a few cases where we need to confirm the satellite name
+    # is correct, one being older, non-archival data, and the other being
+    # if the satellite name is flagged as incorrect (and it may not be due
+    # to a TLE source using an older name)
     if (
         obs_time < Time("2024-05-01T00:00:00.000", format="isot")
         and not is_valid == "archival data"
-    ):
+    ) or is_valid == "Satellite name and number do not match":
         # Temporary fix for satellite name changes - make sure that the
         # current satellite name is used instead of something like
         # "STARLINK K"

--- a/repository/utils/search_utils.py
+++ b/repository/utils/search_utils.py
@@ -30,6 +30,7 @@ def filter_observations(form_data):
         "observer_orcid": "obs_orc_id__icontains",
         "mpc_code": "mpc_code",
         "intl_designator": "satellite_id__intl_designator",
+        "instrument": "instrument__icontains",
     }
 
     observations = Observation.objects.all()


### PR DESCRIPTION
### Description:
Save the current satellite name with the observation data in cases where the satellite name either differs from the current name or is left blank. Also add instrument as a field for the Search page

### Context:
Satellite names can occasionally be out of date in a TLE source (1 incident so far), or using a different name at the time the data was taken that has changed since the data was uploaded, and we only want to save the most current name - especially since name is not a required field and things are more closely tracked by NORAD ID at the moment.

- [x] Tests up to date
- [x] Code documentation up to date
- [x] Project documentation up to date
