### PR TITLE
Paginate search results server-side

### DIFF
--- a/repository/templates/repository/search.html
+++ b/repository/templates/repository/search.html
@@ -129,49 +129,37 @@
             <!-- Results table -->
             {% if observations %}
             <div class="table-container">
-                <table data-toggle="table" data-pagination="true" data-search="true"
-                    data-page-list="[25, 50, 100, 200, All]" data-page-size="25" data-sort-name="added"
-                    data-sort-order="desc" data-classes="table" class="table table-hover fs-6" id="obsTable">
+                <div id="totalResultsMessage"></div>
+                <table id="obsTable"
+                       class="table table-hover"
+                       data-pagination="true"
+                       data-side-pagination="server"
+                       data-url="{% url 'search' %}"
+                       data-method="post"
+                       data-content-type="application/x-www-form-urlencoded"
+                       data-page-list="[25, 50, 100, 200]"
+                       data-page-size="25"
+                       data-sort-name="date_added"
+                       data-sort-order="desc"
+                       data-classes="table-cursor-pointer">
                     <thead>
                         <tr>
-                            <th scope="col" data-sortable="true" data-visible="true">Date added</th>
-                            <th data-field="added" scope="col" data-sortable="true" data-visible="false">
-                                Date_added_timestamp</th>
-                            <th scope="col" data-sortable="true">Name</th>
-                            <th scope="col" data-sortable="true">NORAD ID</th>
-                            <th scope="col" data-sortable="true" data-visible="true" data-sort-name="observed">Date observed</th>
-                            <th data-field="observed" scope="col" data-sortable="true" data-visible="false">Date_observed_timestamp
-                            </th>
-                            <th scope="col" data-sortable="true">Mag</th>
-                            <th scope="col" data-sortable="true">Filter</th>
-                            <th scope="col" data-sortable="true">Latitude (deg)</th>
-                            <th scope="col" data-sortable="true">Longitude (deg)</th>
-                            <th scope="col" data-sortable="true">Altitude (m)</th>
-                            <th scope="col" data-sortable="true">Obs. mode</th>
-                            <th scope="col" data-sortable="true">Observer ORCID</th>
+                            <th data-field="date_added" data-sortable="true">Date added</th>
+                            <th data-field="date_added_timestamp" data-sortable="true" data-visible="false">Date_added_timestamp</th>
+                            <th data-field="satellite_name" data-sortable="true">Name</th>
+                            <th data-field="satellite_number" data-sortable="true">NORAD ID</th>
+                            <th data-field="obs_time_utc" data-sortable="true">Date observed</th>
+                            <th data-field="obs_time_utc_timestamp" data-sortable="true" data-visible="false">Date_observed_timestamp</th>
+                            <th data-field="apparent_mag" data-sortable="true" data-align="right" data-formatter="magnitudeFormatter">Mag</th>
+                            <th data-field="obs_filter" data-sortable="true">Filter</th>
+                            <th data-field="obs_lat_deg" data-sortable="true" data-align="right" data-formatter="numberFormatter">Latitude (deg)</th>
+                            <th data-field="obs_long_deg" data-sortable="true" data-align="right" data-formatter="numberFormatter">Longitude (deg)</th>
+                            <th data-field="obs_alt_m" data-sortable="true" data-align="right" data-formatter="numberFormatter">Altitude (m)</th>
+                            <th data-field="obs_mode" data-sortable="true">Obs. mode</th>
+                            <th data-field="obs_orc_id" data-sortable="true">Observer ORCID</th>
+                            <th data-field="id" data-visible="false">ID</th>
                         </tr>
                     </thead>
-                    <tbody class="table-group-divider clickable">
-                        {% for observation in observations %}
-                        <tr data-bs-toggle="modal" data-bs-target="#obsModal"
-                            data-observation-id="{{ observation.id }}">
-                            <td scope="row">{{ observation.date_added|date:"M. d, Y h:i A" }}</td>
-                            <td scope="row">{{ observation.date_added.timestamp }}</td>
-                            <td scope="row">{{ observation.satellite_id.sat_name }}</td>
-                            <td scope="row">{{ observation.satellite_id.sat_number }}</td>
-                            <td scope="row">{{ observation.obs_time_utc|date:"M. d, Y h:i A" }}</td>
-                            <td scope="row">{{ observation.obs_time_utc.timestamp }}</td>
-                            <td scope="row" class="text-end">{{ observation.apparent_mag|format_magnitude:observation.apparent_mag_uncert }}</td>
-                            <td scope="row">{{ observation.obs_filter }}</td>
-                            <td scope="row" class="text-end">{{ observation.location_id.obs_lat_deg|floatformat:"-4" }}</td>
-                            <td scope="row" class="text-end">{{ observation.location_id.obs_long_deg|floatformat:"-4" }}
-                            </td>
-                            <td scope="row" class="text-end">{{ observation.location_id.obs_alt_m|floatformat:"-4" }}</td>
-                            <td scope="row">{{ observation.obs_mode }}</td>
-                            <td scope="row">{{ observation.obs_orc_id|first }}</td>
-                        </tr>
-                        {% endfor %}
-                    </tbody>
                 </table>
             </div>
             <div class="col p-3">
@@ -198,9 +186,13 @@
         </div>
     </div>
 </div>
+{% endblock %}
 
+{% block extra_js %}
 <script>
     window.SEARCH_URL = "{% url 'search' %}";
 </script>
+<script src="{% static 'js/utils/number_formatting.js' %}"></script>
+<script src="{% static 'js/modal_data.js' %}"></script>
 <script src="{% static 'js/search.js' %}"></script>
 {% endblock %}

--- a/repository/tests/tests_views.py
+++ b/repository/tests/tests_views.py
@@ -204,6 +204,7 @@ class SearchViewTest(TestCase):
         self.assertContains(response, "No observations found")
 
     def test_search_post_empty(self):
+        # Test initial page load with empty search
         response = self.client.post(
             reverse("search"),
             {
@@ -218,7 +219,29 @@ class SearchViewTest(TestCase):
             },
         )
         self.assertEqual(response.status_code, 200)
-        self.assertIn("STARLINK-123", response.content.decode())
+
+        response = self.client.post(
+            reverse("search"),
+            {
+                "sat_name": "",
+                "sat_number": "",
+                "obs_mode": "",
+                "start_date_range": "",
+                "end_date_range": "",
+                "observation_id": "",
+                "observer_orcid": "",
+                "instrument": "",
+                "limit": "25",
+                "offset": "0",
+                "sort": "date_added",
+                "order": "desc",
+            },
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(len(data["rows"]) > 0)
+        self.assertEqual(data["rows"][0]["satellite_name"], "STARLINK-123")
 
     def test_custom_404(self):
         # Test the custom 404 handler

--- a/static/custom.scss
+++ b/static/custom.scss
@@ -5,7 +5,37 @@
   --bs-tooltip-opacity: 0.95;
 }
 
+// Bootstrap Table styles
+.table-cursor-pointer tbody tr {
+  cursor: pointer;
+}
 
+.bootstrap-table {
+  // Prevent any animations/transitions
+  * {
+    transition: none !important;
+  }
+
+  // Set background colors for all table elements
+  .fixed-table-container,
+  .fixed-table-body,
+  .table {
+    background-color: var(--bs-body-bg) !important;
+  }
+
+  // Style loading state
+  .fixed-table-loading {
+    background: var(--bs-body-bg) !important;
+    color: var(--bs-body-color) !important;
+  }
+}
+
+// Dark theme specific styles
+[data-bs-theme="dark"] {
+  .bootstrap-table .table {
+    color: var(--bs-body-color);
+  }
+}
 
 .page-item.active .page-link{
   background-color: map-get($theme-colors, "primary");

--- a/static/js/modal_data.js
+++ b/static/js/modal_data.js
@@ -1,7 +1,13 @@
 document.addEventListener('DOMContentLoaded', function() {
-    // Handle server-side pagination (data_view.html)
-    $('#obsTable').on('click-row.bs.table', function (e, row, $element) {
-        handleObservationClick(row.observation_id, true);
+    // Add global modal cleanup listener
+    document.addEventListener('hidden.bs.modal', function (event) {
+        if (event.target.id === 'obsModal') {
+            document.body.classList.remove('modal-open');
+            const modalBackdrops = document.getElementsByClassName('modal-backdrop');
+            while(modalBackdrops.length > 0) {
+                modalBackdrops[0].remove();
+            }
+        }
     });
 
     // Handle client-side data (index, search, etc.)

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -1,16 +1,117 @@
-document.addEventListener('DOMContentLoaded', function() {
-    // listen for form submit
-    const form = document.querySelector(`form[action="${window.SEARCH_URL}"]`);
+$(function() {
+    // Formatter functions
+    window.magnitudeFormatter = function(value, row) {
+        if (value === null || value === undefined) return '';
+        const uncertainty = row.apparent_mag_uncert;
+        return window.NumberFormatting.roundMagnitude(value, window.NumberFormatting.roundUncertainty(uncertainty));
+    };
 
-    if (form) {
-        form.addEventListener('submit', function() {
-            document.getElementById('searchLoadingIndicator').style.display = 'block';
+    window.numberFormatter = function(value, row) {
+        if (value === null || value === undefined) return '';
+        // Convert to number and round to max 4 decimal places, then convert back to string to remove trailing zeros
+        return Number(Number(value).toFixed(4)).toString();
+    };
 
-            // hide existing results
-            const tableContainer = document.querySelector('.table-container');
-            if (tableContainer) {
-                tableContainer.style.display = 'none';
-            }
+    // Initialize Bootstrap Table
+    var $table = $('#obsTable');
+
+    if ($table.length) {
+        $table.bootstrapTable({
+            pagination: true,
+            sidePagination: 'server',
+            pageList: [25, 50, 100, 200],
+            pageSize: 25,
+            sortName: 'date_added',
+            sortOrder: 'desc',
+            search: true,
+            searchOnEnterKey: false,
+            trimOnSearch: true,
+            searchable: true,
+            paginationVAlign: 'bottom',
+            paginationHAlign: 'right',
+            paginationDetailHAlign: 'left',
+            method: 'POST',
+            contentType: 'application/x-www-form-urlencoded',
+            onClickRow: function(row) {
+                if (row.id) {
+                    var obsModal = new bootstrap.Modal(document.getElementById('obsModal'));
+                    handleObservationClick(row.id, true);
+                }
+            },
+            queryParams: function(params) {
+                // Get the form data
+                const formData = new FormData(document.querySelector('form[action="' + window.SEARCH_URL + '"]'));
+                const searchParams = Object.fromEntries(formData);
+
+                // Show loading indicator
+                document.getElementById('searchLoadingIndicator').style.display = 'block';
+
+                // Map table field names to model field names for sorting
+                const fieldMapping = {
+                    'date_added': 'date_added',
+                    'satellite_name': 'satellite_id__sat_name',
+                    'satellite_number': 'satellite_id__sat_number',
+                    'obs_time_utc': 'obs_time_utc',
+                    'apparent_mag': 'apparent_mag',
+                    'obs_filter': 'obs_filter',
+                    'obs_lat_deg': 'location_id__obs_lat_deg',
+                    'obs_long_deg': 'location_id__obs_long_deg',
+                    'obs_alt_m': 'location_id__obs_alt_m',
+                    'obs_mode': 'obs_mode'
+                };
+
+                return {
+                    ...searchParams,
+                    limit: params.limit,
+                    offset: params.offset,
+                    sort: fieldMapping[params.sort] || params.sort,
+                    order: params.order,
+                    search: params.search,
+                    _csrf: document.querySelector('[name=csrfmiddlewaretoken]').value
+                };
+            },
+            onLoadSuccess: onLoadSuccess,
+            onLoadError: onLoadError
         });
+
+        // Handle form submission
+        const form = document.querySelector(`form[action="${window.SEARCH_URL}"]`);
+        if (form) {
+            form.addEventListener('submit', function(e) {
+                // Allow the form to submit normally if no table exists
+                if (!$table.length) {
+                    return true;
+                }
+
+                e.preventDefault(); // Prevent default form submission
+
+                // Show loading indicator
+                document.getElementById('searchLoadingIndicator').style.display = 'block';
+
+                // Reset table search and refresh with form data
+                $table.bootstrapTable('resetSearch');
+                $table.bootstrapTable('refresh', {
+                    url: window.SEARCH_URL,
+                    pageNumber: 1,
+                    query: {}
+                });
+            });
+        }
     }
 });
+
+function onLoadSuccess(data) {
+    $('#searchLoadingIndicator').hide();
+
+    // Update total results message
+    if (data.total_results > 0) {
+        $('#totalResultsMessage').html(`<p class="text-muted">Found ${data.total_results} observations</p>`);
+    } else {
+        $('#totalResultsMessage').empty();
+    }
+}
+
+function onLoadError(status, res) {
+    $('#searchLoadingIndicator').hide();
+    $('#totalResultsMessage').empty();
+}


### PR DESCRIPTION
### Description:
Add pagination to returning search results

### Context:
Searches with a lot of results were timing out, and even when they didn't it was slower than it could have been to display the results since all were loaded at once before the pagination controls were displayed. It now only shows the first 25 (default page size) with the same options to change number of results per page

JIRA issue: [SOR-138](https://noirlab.atlassian.net/browse/SOR-138)

- [x] Tests up to date
- [x] Code documentation up to date
- [x] Project documentation up to date
