### PR TITLE
Obs by orcid

### DIFF
--- a/repository/templates/repository/observer_view.html
+++ b/repository/templates/repository/observer_view.html
@@ -1,0 +1,92 @@
+{% extends "repository/base.html" %}
+{% load static %}
+
+{% block content %}
+<div class="container-fluid p-3">
+    <div class="container-md">
+        <h2 class="text-center p-2">Observations by {{ orc_id }}</h2>
+        <p>
+            Below are all the observations made by this observer.
+            You can search, sort, and view detailed information about each observation.
+            Click on a row to see more details about a specific observation.
+        </p>
+        <div class="row justify-content-center">
+            <div class="col-12">
+                <table data-toggle="table"
+                       data-pagination="true"
+                       data-search="true"
+                       data-page-list="[25, 50, 100, 200]"
+                       data-page-size="25"
+                       data-sort-name="observed"
+                       data-sort-order="desc"
+                       data-side-pagination="server"
+                       data-url="{% url 'observer-observations' orc_id %}"
+                       data-classes="table"
+                       class="table table-hover fs-6"
+                       id="obsTable">
+                    <thead>
+                        <tr>
+                            <th data-field="sat_name" scope="col" data-sortable="true">Name</th>
+                            <th data-field="sat_number" scope="col" data-sortable="true">NORAD ID</th>
+                            <th data-field="obs_time_utc" scope="col" data-sortable="true" data-sort-name="observed">Date observed (UTC)</th>
+                            <th data-field="observed" scope="col" data-sortable="true" data-visible="false">Date_observed_timestamp</th>
+                            <th data-field="apparent_mag" scope="col" data-sortable="true" data-formatter="magnitudeFormatter">Mag</th>
+                            <th data-field="obs_filter" scope="col" data-sortable="true">Filter</th>
+                            <th data-field="obs_lat_deg" scope="col" data-sortable="true">Latitude (deg)</th>
+                            <th data-field="obs_long_deg" scope="col" data-sortable="true">Longitude (deg)</th>
+                            <th data-field="obs_alt_m" scope="col" data-sortable="true">Altitude (m)</th>
+                            <th data-field="obs_mode" scope="col" data-sortable="true">Obs. mode</th>
+                            <th data-field="observation_id" data-visible="false">ID</th>
+                        </tr>
+                    </thead>
+                    <tbody class="table-group-divider clickable">
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <!-- Download button -->
+        <div class="row mt-3">
+            <div class="col-12 text-end">
+                <form action="{% url 'download-observer-data' %}" method="post">
+                    {% csrf_token %}
+                    <input type="hidden" name="orc_id" value="{{ orc_id }}">
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fas fa-download"></i> Download observations
+                    </button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+{% include "repository/satellites/modal.html" %}
+
+{% endblock %}
+
+{% block extra_js %}
+<script src="{% static 'js/utils/number_formatting.js' %}"></script>
+<script src="{% static 'js/modal_data.js' %}"></script>
+<script>
+    function magnitudeFormatter(value, row) {
+        if (value === null || value === undefined) return '';
+        var apparent_mag_uncert = window.NumberFormatting.roundUncertainty(row.apparent_mag_uncert);
+        return window.NumberFormatting.roundMagnitude(value, apparent_mag_uncert);
+    }
+
+    $(document).ready(function() {
+        // Initialize Bootstrap Table with event handler
+        $('#obsTable').on('click-row.bs.table', function(e, row, $element) {
+            if (row.observation_id) {
+                var obsModal = new bootstrap.Modal(document.getElementById('obsModal'));
+                handleObservationClick(row.observation_id, true);
+            }
+        });
+
+        // Add pointer cursor to all rows
+        $('#obsTable').on('post-body.bs.table', function () {
+            $(this).find('tbody tr').css('cursor', 'pointer');
+        });
+    });
+</script>
+{% endblock %}

--- a/repository/tests/test_tasks.py
+++ b/repository/tests/test_tasks.py
@@ -10,14 +10,14 @@ def test_process_upload_valid_data(mocker):
     mocker.patch("celery_progress.backend.ProgressRecorder.set_progress")
     data = [
         [
-            "PELICAN 3001",
-            "58296",
-            "2020-05-08T21:42:54.572Z",
+            "ACS 3",
+            "59588",
+            "2024-10-03T19:00:27.319Z",
             0.001,
-            6.0418,
-            0.0952,
-            52.01,
-            4.49085,
+            6.6830102,
+            0.096618345,
+            52.15,
+            4.49,
             8,
             10,
             "WATEC 902H2 Supreme + 1.2/85 mm",
@@ -25,12 +25,12 @@ def test_process_upload_valid_data(mocker):
             "CLEAR",
             "test@example.com",
             "0000-0001-6659-9253",
-            185.4465171,
-            25.69768917,
+            342.9184541,
+            16.81681335,
             0,
             0,
             0,
-            571.894,
+            1421.885,
             0,
             0,
             0,
@@ -287,22 +287,22 @@ def test_process_upload_existing_satellite(mocker):
     # Create existing satellite with name
     Satellite.objects.create(
         sat_name="STARLINK-1234",
-        sat_number="58296",
+        sat_number="59588",
         date_added=timezone.now(),
-        intl_designator="2020-001A",
+        intl_designator="2024-001A",
     )
 
     # Test data with same number but no name (archival case)
     data = [
         [
             "",
-            "58296",
-            "2020-05-08T21:42:54.572Z",
+            "59588",
+            "2024-10-03T19:00:27.319Z",
             0.001,
-            6.0418,
-            0.0952,
-            52.01,
-            4.49085,
+            6.6830102,
+            0.096618345,
+            52.15,
+            4.49,
             8,
             10,
             "WATEC 902H2 Supreme + 1.2/85 mm",
@@ -310,12 +310,12 @@ def test_process_upload_existing_satellite(mocker):
             "CLEAR",
             "test@example.com",
             "0000-0001-6659-9253",
-            185.4465171,
-            25.69768917,
+            342.9184541,
+            16.81681335,
             0,
             0,
             0,
-            571.894,
+            1421.885,
             0,
             0,
             0,
@@ -331,9 +331,9 @@ def test_process_upload_existing_satellite(mocker):
     assert Satellite.objects.count() == 1
 
     # Verify existing satellite was used and maintained its data
-    satellite = Satellite.objects.get(sat_number="58296")
+    satellite = Satellite.objects.get(sat_number="59588")
     assert satellite.sat_name == "STARLINK-1234"
-    assert satellite.intl_designator == "2020-001A"
+    assert satellite.intl_designator == "2024-001A"
     assert result["status"] == "success"
 
 
@@ -342,19 +342,19 @@ def test_process_upload_update_empty_name(mocker):
     mocker.patch("celery_progress.backend.ProgressRecorder.set_progress")
 
     # Create satellite with empty name
-    Satellite.objects.create(sat_name="", sat_number="58296", date_added=timezone.now())
+    Satellite.objects.create(sat_name="", sat_number="59588", date_added=timezone.now())
 
     # Test data with name for existing number
     data = [
         [
-            "STARLINK-1234",
-            "58296",
-            "2020-05-08T21:42:54.572Z",
+            "ACS 3",
+            "59588",
+            "2024-10-03T19:00:27.319Z",
             0.001,
-            6.0418,
-            0.0952,
-            52.01,
-            4.49085,
+            6.6830102,
+            0.096618345,
+            52.15,
+            4.49,
             8,
             10,
             "WATEC 902H2 Supreme + 1.2/85 mm",
@@ -362,12 +362,12 @@ def test_process_upload_update_empty_name(mocker):
             "CLEAR",
             "test@example.com",
             "0000-0001-6659-9253",
-            185.4465171,
-            25.69768917,
+            342.9184541,
+            16.81681335,
             0,
             0,
             0,
-            571.894,
+            1421.885,
             0,
             0,
             0,
@@ -380,8 +380,8 @@ def test_process_upload_update_empty_name(mocker):
     result = process_upload(data)
 
     # Verify satellite name was updated
-    satellite = Satellite.objects.get(sat_number="58296")
-    assert satellite.sat_name == "STARLINK-1234"
+    satellite = Satellite.objects.get(sat_number="59588")
+    assert satellite.sat_name == "ACS 3"
     assert result["status"] == "success"
 
 
@@ -391,14 +391,14 @@ def test_process_upload_new_satellites(mocker):
 
     data = [
         [
-            "STARLINK-1234",
-            "58295",
-            "2020-05-08T21:42:54.572Z",
+            "ACS 3",
+            "59588",
+            "2024-10-03T19:00:27.319Z",
             0.001,
-            6.0418,
-            0.0952,
-            52.01,
-            4.49085,
+            6.6830102,
+            0.096618345,
+            52.15,
+            4.49,
             8,
             10,
             "WATEC 902H2 Supreme + 1.2/85 mm",
@@ -407,11 +407,11 @@ def test_process_upload_new_satellites(mocker):
             "test@example.com",
             "0000-0001-6659-9253",
             185.4465171,
-            25.69768917,
+            16.81681335,
             0,
             0,
             0,
-            571.894,
+            1421.885,
             0,
             0,
             0,
@@ -424,16 +424,16 @@ def test_process_upload_new_satellites(mocker):
     result = process_upload(data)
 
     # Verify satellite name was updated
-    satellite = Satellite.objects.get(sat_number="58295")
-    assert satellite.sat_name == "STARLINK-1234"
+    satellite = Satellite.objects.get(sat_number="59588")
+    assert satellite.sat_name == "ACS 3"
     assert result["status"] == "success"
 
-    # Archival case - won't have a name
+    # No name
     data = [
         [
             "",
-            "58297",
-            "2020-05-08T21:42:54.572Z",
+            "58296",
+            "2015-05-08T21:42:54.572Z",
             0.001,
             6.0418,
             0.0952,
@@ -446,8 +446,8 @@ def test_process_upload_new_satellites(mocker):
             "CLEAR",
             "test@example.com",
             "0000-0001-6659-9253",
-            185.4465171,
-            25.69768917,
+            185.2311116,
+            26.15498563,
             0,
             0,
             0,
@@ -463,35 +463,35 @@ def test_process_upload_new_satellites(mocker):
     result = process_upload(data)
     assert result["status"] == "success"
     assert Satellite.objects.count() == 2
-    assert Satellite.objects.get(sat_number="58297").sat_name == ""
+    assert Satellite.objects.get(sat_number="58296").sat_name == ""
 
     data = [
         [
             "",
-            "58296",
-            "2024-05-08T21:42:54.572Z",
-            0.001,
-            6.0418,
-            0.0952,
-            52.01,
-            4.49085,
-            8,
-            10,
-            "WATEC 902H2 Supreme + 1.2/85 mm",
-            "CCD",
+            "58013",
+            "2024-05-08T02:22:45.000Z",
+            1,
+            4,
+            0.2,
+            36.062,
+            -91.688,
+            185,
+            0,
+            "none",
+            "VISUAL",
             "CLEAR",
             "test@example.com",
-            "0000-0001-6659-9253",
-            185.4465171,
-            25.69768917,
+            "0009-0001-8403-8334",
+            185.2311116,
+            26.15498563,
             0,
             0,
             0,
-            571.894,
             0,
             0,
             0,
-            "5-frame average; lim mag of instrument",
+            0,
+            "test obs",
             "",
             "",
         ]
@@ -499,4 +499,4 @@ def test_process_upload_new_satellites(mocker):
     result = process_upload(data)
     assert result["status"] == "success"
     assert Satellite.objects.count() == 3
-    assert Satellite.objects.get(sat_number="58296").sat_name == "PELICAN 3001"
+    assert Satellite.objects.get(sat_number="58013").sat_name == "KUIPER-P2"

--- a/repository/tests/tests_views.py
+++ b/repository/tests/tests_views.py
@@ -99,6 +99,16 @@ class TestViews(TestCase):
         self.assertContains(response, self.satellite.sat_name)
         self.assertContains(response, self.satellite.sat_number)
 
+    def test_observer_obs_list_view(self):
+        response = self.client.get(
+            reverse("observer-view", args=["0123-4567-8910-1112"])
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "repository/observer_view.html")
+
+        orcid = self.observation.obs_orc_id[0].replace("[", "").replace("]", "")
+        self.assertContains(response, orcid)
+
     def test_last_observer_location_with_observations(self):
         response = self.client.post(
             reverse("last_observer_location"),

--- a/repository/urls.py
+++ b/repository/urls.py
@@ -51,5 +51,16 @@ urlpatterns = [
         name="get_observation_by_id",
     ),
     path("launch/<str:launch_number>/", views.launch_view, name="launch-view"),
+    path("observer/<str:orc_id>/", views.observer_view, name="observer-view"),
+    path(
+        "observer/<str:orc_id>/observations/",
+        views.observer_observations,
+        name="observer-observations",
+    ),
     path("api/", api.urls),
+    path(
+        "download-observer-data/",
+        views.download_observer_data,
+        name="download-observer-data",
+    ),
 ]

--- a/repository/utils/csv_utils.py
+++ b/repository/utils/csv_utils.py
@@ -64,7 +64,7 @@ def get_csv_header() -> list[str]:
 
 
 def create_csv(
-    observation_list: list[Observation], satellite_name: str
+    observation_list: list[Observation], prefix: str
 ) -> tuple[io.BytesIO, str]:
     """
     Creates a CSV file from a list of observations and compresses it into a zip file.
@@ -76,7 +76,7 @@ def create_csv(
 
     Args:
         observation_list (List[Observation]): A list of Observation objects.
-
+        prefix (str): A prefix for the zip file name.
     Returns:
         Tuple[io.BytesIO, str]: A tuple containing the compressed zip file and the
         name of the zip file.
@@ -91,6 +91,13 @@ def create_csv(
         all_observations = True
 
     observation_list = observation_list.select_related("satellite_id", "location_id")
+
+    if prefix:
+        file_name = f"{prefix}_observations"
+    elif all_observations:
+        file_name = "satellite_observations_all"
+    else:
+        file_name = "satellite_observations_search_results"
 
     header = get_csv_header()
     logger.info("CSV header retrieved")
@@ -171,17 +178,10 @@ def create_csv(
                 writer.writerows(csv_lines)
 
             # Write the CSV content to the zip file as bytes
-            zip.writestr("observations.csv", csv_file.getvalue().encode("utf-8"))
+            zip.writestr(f"{file_name}.csv", csv_file.getvalue().encode("utf-8"))
 
     zipped_file.seek(0)
-    if satellite_name:
-        zipfile_name = f"{satellite_name}_observations.zip"
-    else:
-        zipfile_name = (
-            "satellite_observations_all.zip"
-            if all_observations
-            else "satellite_observations_search_results.zip"
-        )
+    zipfile_name = f"{file_name}.zip"
 
     logger.info(f"Zipping the CSV file took {time.time() - start_time:.4f} seconds")
     logger.info(

--- a/repository/utils/general_utils.py
+++ b/repository/utils/general_utils.py
@@ -269,6 +269,11 @@ def validate_position(
         Union[str, bool]: An error message if the validation fails.
                           True if the validation is successful.
     """
+    if (
+        response.status_code == 500
+        and "Error: TLE date out of range" in response.json().get("message")
+    ):
+        return "archival data"
     if response.status_code != 200:
         return "Satellite position check failed - verify uploaded data is correct."
     response_data = response.json()

--- a/static/js/modal_data.js
+++ b/static/js/modal_data.js
@@ -38,7 +38,15 @@ function populateModalFields(observation) {
     document.getElementById('observation_id_label').textContent = observation.id;
     document.getElementById('satellite_name').innerHTML = '<a href="' + satelliteDataViewUrl + '">'+ observation.satellite_id.sat_name +'</a>';
     document.getElementById('satellite_number').textContent = observation.satellite_id.sat_number;
-    document.getElementById('intl_designator').textContent = observation.satellite_id.intl_designator;
+
+    // Make the international designator clickable if it exists
+    if (observation.satellite_id.intl_designator) {
+        const baseDesignator = observation.satellite_id.intl_designator.slice(0, 8);
+        document.getElementById('intl_designator').innerHTML = `<a href="/launch/${baseDesignator}/">${observation.satellite_id.intl_designator}</a>`;
+    } else {
+        document.getElementById('intl_designator').textContent = "";
+    }
+
     document.getElementById('obs_time_utc').textContent = observation.obs_time_utc;
     document.getElementById('obs_time_uncert').textContent = observation.obs_time_uncert_sec;
     document.getElementById('date_added_label').textContent = observation.date_added;
@@ -50,7 +58,10 @@ function populateModalFields(observation) {
     document.getElementById('obs_mode').textContent = observation.obs_mode;
     document.getElementById('obs_filter').textContent = observation.obs_filter;
     document.getElementById('obs_instrument').textContent = observation.instrument;
-    document.getElementById('obs_orc_id').innerHTML = observation.obs_orc_id.toString().replace(/,/g, ',<br/>');
+
+    // Add ORCID link
+    var orcId = observation.obs_orc_id.toString().replace(/,/g, ',<br/>');
+    document.getElementById('obs_orc_id').innerHTML = `<a href="/observer/${orcId}/">${orcId}</a>`;
 
     // Populate additional fields
     populateIfExists('obs_comments', observation);
@@ -80,15 +91,6 @@ function populateModalFields(observation) {
         document.getElementById('data_archive_link').innerHTML = '<a href="' + observation.data_archive_link + '">Data link</a>';
     } else {
         document.getElementById('data_archive_link').textContent = "";
-    }
-
-    // Add launch link only if there's an international designator
-    const launchLinkContainer = document.getElementById('launch_link_container');
-    if (observation.satellite_id.intl_designator) {
-        const baseDesignator = observation.satellite_id.intl_designator.slice(0, 8);
-        launchLinkContainer.innerHTML = `<a href="/launch/${baseDesignator}/">View other objects from this launch</a>`;
-    } else {
-        launchLinkContainer.innerHTML = '';
     }
 }
 


### PR DESCRIPTION
### Description:
* Link observations when clicking on the ORCID on the observations detail view - opens  a separate page with all observations by that observer that can also be downloaded
* Update test data for tests that were failing due to the new error from SatChecker if the TLE date was too far out of range from the requested date
* Ensure all CSV files have relevant names and not just "observations.csv"



JIRA issue: [SOR-139](https://noirlab.atlassian.net/browse/SOR-139)

- [x] Tests up to date
- [x] Code documentation up to date
- [x] Project documentation up to date
