### PR TITLE
Fix ORCID validation to allow 'X' at the end

### DIFF
--- a/repository/forms.py
+++ b/repository/forms.py
@@ -28,7 +28,7 @@ def validate_orcid(value: str) -> None:
     """
     orc_id_list = value.split(",")
     for orc_id in orc_id_list:
-        if not re.match(r"^\d{4}-\d{4}-\d{4}-\d{4}$", orc_id.strip()):
+        if not re.match(r"^\d{4}-\d{4}-\d{4}-\d{3}[0-9Xx]$", orc_id.strip()):
             raise forms.ValidationError("Invalid ORCID.")
 
 
@@ -150,6 +150,11 @@ class SearchForm(Form):
                     "If any of latitude, longitude, or radius "
                     "is provided, all three must be specified for observer location."
                 )
+
+        # Normalize ORCID if provided
+        observer_orcid = cleaned_data.get("observer_orcid")
+        if observer_orcid:
+            cleaned_data["observer_orcid"] = observer_orcid.upper()
 
         return cleaned_data
 
@@ -490,6 +495,12 @@ class GenerateCSVForm(Form):
                 "apparent magnitude uncertainty is provided."
             )
         # fmt: on
+
+        # Normalize ORCID if provided
+        observer_orcid = cleaned_data.get("observer_orcid")
+        if observer_orcid:
+            cleaned_data["observer_orcid"] = observer_orcid.upper()
+
         if errors:
             raise forms.ValidationError(errors)
 

--- a/repository/models.py
+++ b/repository/models.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 
 
 def validate_orcid(value):
-    pattern = re.compile(r"^\d{4}-\d{4}-\d{4}-\d{4}$")
+    pattern = re.compile(r"^\d{4}-\d{4}-\d{4}-\d{3}[0-9Xx]$")
     for orc_id in value:
         if not pattern.match(orc_id):
             raise ValidationError(f"{orc_id} is not a valid ORCID")
@@ -188,6 +188,12 @@ class Observation(models.Model):
             )
         if self.obs_orc_id and self.obs_orc_id[0] == "":
             raise ValidationError("ORCID cannot be empty.")
+
+        # Normalize ORCIDs
+        if self.obs_orc_id:
+            self.obs_orc_id = [
+                orc_id.upper() if orc_id else orc_id for orc_id in self.obs_orc_id
+            ]
 
     def save(self, *args, **kwargs):
         self.full_clean()

--- a/repository/templates/repository/about.html
+++ b/repository/templates/repository/about.html
@@ -34,8 +34,8 @@
         for the Protection of the Dark and Quiet Sky from Satellite Constellation Interference (IAU CPS) SatHub.
         The development of SCORE has been supported by the National Science Foundation (NSF) under grant number: AST 2332736.
         SCORE is hosted at the NSF NOIRLab. Any opinions, findings, and conclusions or recommendations expressed in this material are
-        those of the author(s) and do not necessarily reflect the views of the National Science Foundation or the International
-        Astronomical Union."
+        those of the author(s) and do not necessarily reflect the views of the NSF NOIRLab, the SKAO, the IAU, or any host or member
+        institution of the IAU CPS."
       </blockquote>
     </div>
 

--- a/repository/templates/repository/getting-started.html
+++ b/repository/templates/repository/getting-started.html
@@ -102,7 +102,8 @@
             All SCORE data is freely available under a CC-BY 4.0 license. When using SCORE data in publications, please include the following acknowledgement (available in the <a href="{% url 'policy' %}">SCORE Use Policy</a>):
           </p>
           <blockquote class="fst-italic border border-secondary rounded p-3">
-            "This research made use of data and/or services provided by the International Astronomical Union's Centre for the Protection of the Dark and Quiet Sky from Satellite Constellation Interference (IAU CPS). The development of SCORE has been supported by the National Science Foundation (NSF) under grant number: AST 2332736. SCORE is hosted at the NSF NOIRLab. Any opinions, findings, and conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the National Science Foundation or the International Astronomical Union."
+            "This research made use of data and/or services provided by the International Astronomical Union's Centre for the Protection of the Dark and Quiet Sky from Satellite Constellation Interference (IAU CPS). The development of SCORE has been supported by the National Science Foundation (NSF) under grant number: AST 2332736. SCORE is hosted at the NSF NOIRLab. Any opinions, findings, and conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the NSF NOIRLab, the SKAO, the IAU, or any host or member
+            institution of the IAU CPS."
           </blockquote>
         </div>
 

--- a/repository/tests/test_forms.py
+++ b/repository/tests/test_forms.py
@@ -178,3 +178,142 @@ class GenerateCSVFormTest(TestCase):
             },
         )
         self.assertFalse(response.context["form"].is_valid())
+
+    def test_orcid_validation_with_lowercase_x(self):
+        form = GenerateCSVForm(
+            {
+                "sat_number": 12345,
+                "obs_date_year": 2024,
+                "obs_date_month": 1,
+                "obs_date_day": 2,
+                "obs_date_hour": 23,
+                "obs_date_min": 59,
+                "obs_date_sec": 59,
+                "obs_date_uncert": 0.01,
+                "apparent_mag": 8.1,
+                "apparent_mag_uncert": 0.01,
+                "limiting_magnitude": 10,
+                "observer_latitude_deg": 33,
+                "observer_longitude_deg": -117,
+                "observer_altitude_m": 100,
+                "obs_mode": "VISUAL",
+                "filter": "CLEAR",
+                "instrument": "n/a",
+                "observer_email": "abc@123.com",
+                "observer_orcid": "1234-5678-1234-567x",
+            }
+        )
+        self.assertTrue(form.is_valid())
+        # Check that the ORCID was normalized to uppercase
+        self.assertEqual(form.cleaned_data["observer_orcid"], "1234-5678-1234-567X")
+
+    def test_orcid_validation_with_uppercase_x(self):
+        form = GenerateCSVForm(
+            {
+                "sat_number": 12345,
+                "obs_date_year": 2024,
+                "obs_date_month": 1,
+                "obs_date_day": 2,
+                "obs_date_hour": 23,
+                "obs_date_min": 59,
+                "obs_date_sec": 59,
+                "obs_date_uncert": 0.01,
+                "apparent_mag": 8.1,
+                "apparent_mag_uncert": 0.01,
+                "limiting_magnitude": 10,
+                "observer_latitude_deg": 33,
+                "observer_longitude_deg": -117,
+                "observer_altitude_m": 100,
+                "obs_mode": "VISUAL",
+                "filter": "CLEAR",
+                "instrument": "n/a",
+                "observer_email": "abc@123.com",
+                "observer_orcid": "1234-5678-1234-567X",
+            }
+        )
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data["observer_orcid"], "1234-5678-1234-567X")
+
+    def test_orcid_validation_multiple_orcids_mixed_case(self):
+        form = GenerateCSVForm(
+            {
+                "sat_number": 12345,
+                "obs_date_year": 2024,
+                "obs_date_month": 1,
+                "obs_date_day": 2,
+                "obs_date_hour": 23,
+                "obs_date_min": 59,
+                "obs_date_sec": 59,
+                "obs_date_uncert": 0.01,
+                "apparent_mag": 8.1,
+                "apparent_mag_uncert": 0.01,
+                "limiting_magnitude": 10,
+                "observer_latitude_deg": 33,
+                "observer_longitude_deg": -117,
+                "observer_altitude_m": 100,
+                "obs_mode": "VISUAL",
+                "filter": "CLEAR",
+                "instrument": "n/a",
+                "observer_email": "abc@123.com",
+                "observer_orcid": "1234-5678-1234-567x, 9876-5432-1098-765X",
+            }
+        )
+        self.assertTrue(form.is_valid())
+        self.assertEqual(
+            form.cleaned_data["observer_orcid"],
+            "1234-5678-1234-567X, 9876-5432-1098-765X",
+        )
+
+    def test_orcid_validation_with_invalid_character(self):
+        form = GenerateCSVForm(
+            {
+                "sat_number": 12345,
+                "obs_date_year": 2024,
+                "obs_date_month": 1,
+                "obs_date_day": 2,
+                "obs_date_hour": 23,
+                "obs_date_min": 59,
+                "obs_date_sec": 59,
+                "obs_date_uncert": 0.01,
+                "apparent_mag": 8.1,
+                "apparent_mag_uncert": 0.01,
+                "limiting_magnitude": 10,
+                "observer_latitude_deg": 33,
+                "observer_longitude_deg": -117,
+                "observer_altitude_m": 100,
+                "obs_mode": "VISUAL",
+                "filter": "CLEAR",
+                "instrument": "n/a",
+                "observer_email": "abc@123.com",
+                "observer_orcid": "1234-5678-1234-567Y",
+            }
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("observer_orcid", form.errors)
+        self.assertEqual(form.errors["observer_orcid"], ["Invalid ORCID."])
+
+    def test_search_form_orcid_validation_with_lowercase_x(self):
+        from repository.forms import SearchForm
+
+        form = SearchForm({"observer_orcid": "1234-5678-1234-567x"})
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data["observer_orcid"], "1234-5678-1234-567X")
+
+    def test_search_form_orcid_validation_with_uppercase_x(self):
+        from repository.forms import SearchForm
+
+        form = SearchForm({"observer_orcid": "1234-5678-1234-567X"})
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data["observer_orcid"], "1234-5678-1234-567X")
+
+    def test_search_form_orcid_validation_multiple_orcids_with_mixed_case(self):
+        from repository.forms import SearchForm
+
+        form = SearchForm(
+            {"observer_orcid": "1234-5678-1234-567x, 9876-5432-1098-765X"}
+        )
+        self.assertTrue(form.is_valid())
+        self.assertEqual(
+            form.cleaned_data["observer_orcid"],
+            "1234-5678-1234-567X, 9876-5432-1098-765X",
+        )

--- a/repository/tests/tests_models.py
+++ b/repository/tests/tests_models.py
@@ -325,3 +325,29 @@ class ObservationTest(TestCase):
         # valid values successful
         obs = self.create_observation()
         obs.full_clean()
+
+    def test_orcid_validation_with_lowercase_x(self):
+        obs = self.create_observation(obs_orc_id=["1234-5678-1234-567x"], sat_number=20)
+        obs.full_clean()
+        # Check that the ORCID was normalized to uppercase
+        self.assertEqual(obs.obs_orc_id, ["1234-5678-1234-567X"])
+
+    def test_orcid_validation_with_uppercase_x(self):
+        obs = self.create_observation(obs_orc_id=["1234-5678-1234-567X"], sat_number=21)
+        obs.full_clean()
+        self.assertEqual(obs.obs_orc_id, ["1234-5678-1234-567X"])
+
+    def test_orcid_validation_multiple_orcids_mixed_case(self):
+        obs = self.create_observation(
+            obs_orc_id=["1234-5678-1234-567x", "9876-5432-1098-765X"], sat_number=22
+        )
+        obs.full_clean()
+        self.assertEqual(obs.obs_orc_id, ["1234-5678-1234-567X", "9876-5432-1098-765X"])
+
+    def test_orcid_validation_with_invalid_character(self):
+        with self.assertRaises(ValidationError) as error:
+            obs = self.create_observation(
+                obs_orc_id=["1234-5678-1234-567Y"], sat_number=23
+            )
+            obs.full_clean()
+        self.assertIn("not a valid ORCID", str(error.exception))

--- a/repository/views.py
+++ b/repository/views.py
@@ -400,7 +400,11 @@ def search(request):
                 },
             )
         else:
-            return render(request, "repository/search.html", {"form": form})
+            return render(
+                request,
+                "repository/search.html",
+                {"error": "No observations found.", "form": form},
+            )
 
     return render(request, "repository/search.html", {"form": SearchForm()})
 

--- a/static/js/generate_csv_utils.js
+++ b/static/js/generate_csv_utils.js
@@ -171,9 +171,15 @@ $('[data-toggle="tooltip"]').tooltip();
                 }
                 break;
             case 'observer_orcid':
-                if (value && !/^\d{4}-\d{4}-\d{4}-\d{4}$/.test(value)) {
+                if (value && !/^\d{4}-\d{4}-\d{4}-\d{3}[0-9Xx]$/.test(value)) {
                     isValid = false;
                     errorMessage = 'Invalid ORCID format.';
+                } else if (value) {
+                    // Normalize ORCID by converting to uppercase
+                    var normalizedValue = value.toUpperCase();
+                    if (normalizedValue !== value) {
+                        $(field).val(normalizedValue);
+                    }
                 }
                 break;
             case 'sat_number':


### PR DESCRIPTION
### Description:
ORCID validation on the Generate CSV Form only allowed numbers, but the last character of an ORCID id can be an X to designate a 10. Form validation was fixed for the Generate CSV and search forms, plus model validation on data upload.

- [ ] Tests up to date
- [ ] Code documentation up to date
- [ ] Project documentation up to date
