### PR TITLE
Add satellite generation from metadata to individual satellite page when available

### DIFF
--- a/repository/templates/repository/satellites/data_view.html
+++ b/repository/templates/repository/satellites/data_view.html
@@ -57,6 +57,7 @@
                   <p><strong>NORAD ID:</strong> <span id="norad_id">{{ satellite.sat_number }}</span></p>
                   <p><strong>COSPAR ID:</strong> <span id="sat_intl_designator">{{ intl_designator|default:"N/A" }}</span><br />
                   <a href="{% url 'launch-view' intl_designator|slice:":8" %}">View other objects from this launch</a></p>
+                  <p><strong>Generation:</strong> <span id="generation">{{ generation|default:"N/A" }}</span></p>
                 </div>
                 <div class="col-md-4">
                   <p>

--- a/repository/utils/general_utils.py
+++ b/repository/utils/general_utils.py
@@ -443,6 +443,7 @@ def get_satellite_metadata(satellite_number: str) -> Optional[dict[str, Optional
                 "name": metadata.get("name"),
                 "norad_id": metadata.get("norad_id"),
                 "international_designator": metadata.get("international_designator"),
+                "generation": metadata.get("generation"),
             }
         else:
             logger.warning(f"No metadata found for satellite {satellite_number}")

--- a/repository/views.py
+++ b/repository/views.py
@@ -677,6 +677,7 @@ def satellite_data_view(request, satellite_number):
         "intl_designator": (
             metadata.get("international_designator") if metadata else None
         ),
+        "generation": metadata.get("generation") if metadata else None,
         "obs_ids": [observation.id for observation in observations],
     }
 


### PR DESCRIPTION
### Description:
Since the SatChecker endpoint to get satellite metadata now includes the generation for Starlink satellites (when available), this can be added to the individual satellite info pages in the top section with other satellite information. If not available, the generation will display "N/A" like other data points without info in SatChecker


- [x] Tests up to date
- [x] Code documentation up to date
- [x] Project documentation up to date
